### PR TITLE
Added upper bound parameter integration to DAISIE scripts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,5 +50,3 @@ Imports:
     DAISIE (>= 4.2.1),
     ggplot2,
     cowplot
-Remotes: 
-    rsetienne/DAISIE@relaxed

--- a/R/default_params_doc.R
+++ b/R/default_params_doc.R
@@ -202,6 +202,10 @@
 #'   of the largest clade.
 #' @param prop_type2_pool A numeric determining the proportion of the mainland
 #'   species pool that is composed on type 2 species.
+#' @param par_upper_bound A numeric defining the upper limit of the integration
+#'   of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+#'   model being applied is not the relaxed-rate model, this parameter can be
+#'   ignored and left as its default as it does not influence the model.
 #'
 #' @return Nothing
 #' @keywords internal
@@ -244,6 +248,7 @@ default_params_doc <- function(model,
                                low_rates,
                                rep_index,
                                res,
-                               prop_type2_pool) {
+                               prop_type2_pool,
+                               par_upper_bound) {
   # Nothing
 }

--- a/R/run_daisie_ml.R
+++ b/R/run_daisie_ml.R
@@ -30,6 +30,7 @@ run_daisie_ml <- function(daisie_data,
                           low_rates = FALSE,
                           rep_index = "NULL",
                           res = 100,
+                          par_upper_bound = Inf,
                           test = FALSE) {
   if (test) {
     seed <- array_index
@@ -63,7 +64,8 @@ run_daisie_ml <- function(daisie_data,
 
   model_arguments <- setup_model(
     model = model,
-    low_rates = low_rates
+    low_rates = low_rates,
+    par_upper_bound = par_upper_bound
   )
 
   initparsopt <- model_arguments$initparsopt

--- a/R/setup_model.R
+++ b/R/setup_model.R
@@ -12,7 +12,8 @@
 #'   model = model
 #' )
 setup_model <- function(model,
-                        low_rates = FALSE) {
+                        low_rates = FALSE,
+                        par_upper_bound = Inf) {
   expected_models <- get_available_models()
   testit::assert(model %in% expected_models)
 
@@ -75,31 +76,36 @@ setup_model <- function(model,
     if (grepl("rr_lac", model)) {
       cs_version <- DAISIE::create_CS_version(
         model = 2,
-        relaxed_par = "cladogenesis"
+        relaxed_par = "cladogenesis",
+        par_upper_bound = par_upper_bound
       )
     }
     if (grepl("rr_mu", model)) {
       cs_version <- DAISIE::create_CS_version(
         model = 2,
-        relaxed_par = "extinction"
+        relaxed_par = "extinction",
+        par_upper_bound = par_upper_bound
       )
     }
     if (grepl("rr_k", model)) {
       cs_version <- DAISIE::create_CS_version(
         model = 2,
-        relaxed_par = "carrying_capacity"
+        relaxed_par = "carrying_capacity",
+        par_upper_bound = par_upper_bound
       )
     }
     if (grepl("rr_gam", model)) {
       cs_version <- DAISIE::create_CS_version(
         model = 2,
-        relaxed_par = "immigration"
+        relaxed_par = "immigration",
+        par_upper_bound = par_upper_bound
       )
     }
     if (grepl("rr_laa", model)) {
       cs_version <- DAISIE::create_CS_version(
         model = 2,
-        relaxed_par = "anagenesis"
+        relaxed_par = "anagenesis",
+        par_upper_bound = par_upper_bound
       )
     }
   }

--- a/bash/submit_run_daisie_ml.sh
+++ b/bash/submit_run_daisie_ml.sh
@@ -53,6 +53,10 @@
 # res - A numeric determining the resolution of the likelihood calculations, it
 # sets the limit for the maximum number of species for which a probability
 # must be computed, which must be larger than the size of the largest clade
+# par_upper_bound - A numeric defining the upper limit of the integration
+# of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+# model being applied is not the relaxed-rate model, this parameter can be
+# ignored and left as its default as it does not influence the model
 
 ################################################################################
 ##### Before running make sure install_DAISIEutils.sh has been run ####
@@ -74,6 +78,7 @@ optimmethod=${7-subplex}
 low_rates=${8-FALSE}
 rep_index=${9-NULL}
 res=${10-100}
+par_upper_bound=${11-Inf}
 seed=${SLURM_ARRAY_TASK_ID}
 
 ml R
@@ -87,4 +92,5 @@ Rscript DAISIEutils/scripts/run_daisie_ml.R ${data} \
                                             ${optimmethod} \
                                             ${low_rates} \
                                             ${rep_index} \
-                                            ${res}
+                                            ${res} \
+                                            ${par_upper_bound}

--- a/bash/submit_run_daisie_ml_long.sh
+++ b/bash/submit_run_daisie_ml_long.sh
@@ -53,6 +53,10 @@
 # res - A numeric determining the resolution of the likelihood calculations, it
 # sets the limit for the maximum number of species for which a probability
 # must be computed, which must be larger than the size of the largest clade
+# par_upper_bound - A numeric defining the upper limit of the integration
+# of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+# model being applied is not the relaxed-rate model, this parameter can be
+# ignored and left as its default as it does not influence the model
 
 ################################################################################
 ##### Before running make sure install_DAISIEutils.sh has been run ####
@@ -73,6 +77,7 @@ optimmethod=${7-subplex}
 low_rates=${8-FALSE}
 rep_index=${9-NULL}
 res=${10-100}
+par_upper_bound=${11-Inf}
 seed=${SLURM_ARRAY_TASK_ID}
 
 ml R
@@ -86,4 +91,5 @@ Rscript DAISIEutils/scripts/run_daisie_ml.R ${data} \
                                             ${optimmethod} \
                                             ${low_rates} \
                                             ${rep_index} \
-                                            ${res}
+                                            ${res} \
+                                            ${par_upper_bound}

--- a/man/default_params_doc.Rd
+++ b/man/default_params_doc.Rd
@@ -43,7 +43,8 @@ default_params_doc(
   low_rates,
   rep_index,
   res,
-  prop_type2_pool
+  prop_type2_pool,
+  par_upper_bound
 )
 }
 \arguments{
@@ -293,6 +294,11 @@ of the largest clade.}
 
 \item{prop_type2_pool}{A numeric determining the proportion of the mainland
 species pool that is composed on type 2 species.}
+
+\item{par_upper_bound}{A numeric defining the upper limit of the integration
+of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+model being applied is not the relaxed-rate model, this parameter can be
+ignored and left as its default as it does not influence the model.}
 }
 \value{
 Nothing

--- a/man/run_daisie_ml.Rd
+++ b/man/run_daisie_ml.Rd
@@ -16,6 +16,7 @@ run_daisie_ml(
   low_rates = FALSE,
   rep_index = "NULL",
   res = 100,
+  par_upper_bound = Inf,
   test = FALSE
 )
 }
@@ -145,6 +146,11 @@ a DAISIE model to a posterior distribution of data.}
 calculations, it sets the limit for the maximum number of species for
 which a probability must be computed, which must be larger than the size
 of the largest clade.}
+
+\item{par_upper_bound}{A numeric defining the upper limit of the integration
+of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+model being applied is not the relaxed-rate model, this parameter can be
+ignored and left as its default as it does not influence the model.}
 
 \item{test}{A boolean, defaults to \code{FALSE}. Set to \code{TRUE} for testing
 purposes, to fix the seed.}

--- a/man/setup_model.Rd
+++ b/man/setup_model.Rd
@@ -4,7 +4,7 @@
 \alias{setup_model}
 \title{Set up DAISIE_ML arguments}
 \usage{
-setup_model(model, low_rates = FALSE)
+setup_model(model, low_rates = FALSE, par_upper_bound = Inf)
 }
 \arguments{
 \item{model}{A string with model that should run. Models are as follows:
@@ -80,6 +80,11 @@ restricted range where the initial rates a ensured to be smaller (TRUE).
 The latter helps when using large datasets that may fail the initial
 likelihood computation with higher rates that could be sampled from the
 broad range of rates.}
+
+\item{par_upper_bound}{A numeric defining the upper limit of the integration
+of a parameter when fitting the relaxed-rate DAISIE model. If the DAISIE
+model being applied is not the relaxed-rate model, this parameter can be
+ignored and left as its default as it does not influence the model.}
 }
 \value{
 A named list with \code{\link[DAISIE:DAISIE_ML]{DAISIE::DAISIE_ML()}} arguments.

--- a/scripts/run_daisie_ml.R
+++ b/scripts/run_daisie_ml.R
@@ -21,7 +21,8 @@ if (identical(args[6], "NULL")) {
     optimmethod = args[8],
     low_rates = as.logical(args[9]),
     rep_index = args[10],
-    res = as.numeric(args[11])
+    res = as.numeric(args[11]),
+    par_upper_bound = as.numeric(args[12])
   )
 } else if (identical(args[6], "NA")){
   DAISIEutils::run_daisie_ml(
@@ -35,7 +36,8 @@ if (identical(args[6], "NULL")) {
     optimmethod = args[8],
     low_rates = as.logical(args[9]),
     rep_index = args[10],
-    res = as.numeric(args[11])
+    res = as.numeric(args[11]),
+    par_upper_bound = as.numeric(args[12])
   )
 } else {
   DAISIEutils::run_daisie_ml(
@@ -49,6 +51,7 @@ if (identical(args[6], "NULL")) {
     optimmethod = args[8],
     low_rates = as.logical(args[9]),
     rep_index = args[10],
-    res = as.numeric(args[11])
+    res = as.numeric(args[11]),
+    par_upper_bound = as.numeric(args[12])
   )
 }


### PR DESCRIPTION
This is a small change to the package that allows an upper bound to be given when running the relaxed-rate model.

@Neves-P I'm tagging you as a reviewer mainly to check whether these changes influence your analyses. We can discuss the changes or wait until we make a PR from develop to master before reviewing. Just wanted to make sure it didn't mess up any of your stuff.