### PR TITLE
Prevent infinite initial parameters passed to relaxed-rate model

### DIFF
--- a/R/run_daisie_ml.R
+++ b/R/run_daisie_ml.R
@@ -102,6 +102,9 @@ run_daisie_ml <- function(daisie_data,
 
     # extract DAISIE parameters for initial parameters
     initparsopt[1:5] <- unlist(lik_res)[1:5]
+
+    # prevent infinite parameter estimates given as initial parameters
+    initparsopt[is.infinite(initparsopt)] <- 1e5
   }
 
   ##### ML Optimization ####


### PR DESCRIPTION
This PR addresses a bug whereby the initial CS DAISIE model which estimates parameters to be passed to the relaxed-rate model was sometimes passing infinite values. This was the case for the carrying capacity ($K$) which can be estimated as `Inf` when the model favours diversity-independence.

@Neves-P I'm going to merge this PR once all the CI checks pass. This is a minor change and should only influence running the relaxed-rate model. If you spot an issue please let me know and I will open a subsequent PR to resolve it. 