### PR TITLE
Restrict values passed from initial optimisation to relaxed-rate model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DAISIEutils
 Title: Utility Functions for the DAISIE Package
-Date: 2023-05-03
+Date: 2023-10-08
 Version: 1.6.1
 Authors@R: c(
     person(given = "Pedro",

--- a/R/run_daisie_ml.R
+++ b/R/run_daisie_ml.R
@@ -109,7 +109,7 @@ run_daisie_ml <- function(daisie_data,
     # prevent initial parameters being greater than upper parameter limit
     pick <- which(c("cladogenesis", "extinction", "carrying_capacity",
                     "immigration", "anagenesis") == cs_version$relaxed_par)
-    initparsopt[initparsopt[pick] > par_upper_bound] <- par_upper_bound
+    initparsopt[initparsopt[pick] > par_upper_bound] <- par_upper_bound / 2
   }
 
   ##### ML Optimization ####

--- a/R/run_daisie_ml.R
+++ b/R/run_daisie_ml.R
@@ -105,6 +105,11 @@ run_daisie_ml <- function(daisie_data,
 
     # prevent infinite parameter estimates given as initial parameters
     initparsopt[is.infinite(initparsopt)] <- 1e5
+
+    # prevent initial parameters being greater than upper parameter limit
+    pick <- which(c("cladogenesis", "extinction", "carrying_capacity",
+                    "immigration", "anagenesis") == cs_version$relaxed_par)
+    initparsopt[initparsopt[pick] > par_upper_bound] <- par_upper_bound
   }
 
   ##### ML Optimization ####

--- a/R/run_daisie_ml.R
+++ b/R/run_daisie_ml.R
@@ -104,7 +104,7 @@ run_daisie_ml <- function(daisie_data,
     initparsopt[1:5] <- unlist(lik_res)[1:5]
 
     # prevent infinite parameter estimates given as initial parameters
-    initparsopt[is.infinite(initparsopt)] <- 1e5
+    initparsopt[initparsopt > 1e3] <- 1e3
 
     # prevent initial parameters being greater than upper parameter limit
     pick <- which(c("cladogenesis", "extinction", "carrying_capacity",


### PR DESCRIPTION
This PR puts an upper limit on initial parameter values that can be passed into the relaxed-rate DAISIE model. The upper limits are dependent on not allowing infinite values passed into DAISIE and to prevent values about the specified parameter upper bound.

@Neves-P If you agree I will make a minor version release after these changes are merged.