### PR TITLE
Increase run DAISIE ml short jobs time

### DIFF
--- a/bash/submit_run_daisie_2type_ml.sh
+++ b/bash/submit_run_daisie_2type_ml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=02:00:00
+#SBATCH --time=05:00:00
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --job-name=daisie_ml

--- a/bash/submit_run_daisie_ml.sh
+++ b/bash/submit_run_daisie_ml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --time=02:00:00
+#SBATCH --time=05:00:00
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --job-name=daisie_ml


### PR DESCRIPTION
This PR increase the job time allocation for short DAISIE ML jobs from 2 hours to 5 hours. This is to ensure that large datasets or complex DAISIE models can finish optimisation before being terminated. If the job takes longer we recommend using the `_long.sh` bash scripts which allocate 10 days of running.

@Neves-P I set this to 5 hours as this should be plenty for DAISIE optimisation to finish (some of my jobs we being cut off by the 2 hour limit). I'm unsure of what the slurm algorithm is for prioritising jobs based on time allocation, I'm hoping 5 hours is still considered a "short job". Let me know if you think we should change this. Assuming all the CI checks pass I will merge this into `develop` and then `main`.